### PR TITLE
add single product component page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3547,6 +3547,11 @@
         "next-tick": "1"
       }
     },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -7141,8 +7146,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-property": {
       "version": "1.0.2",
@@ -7772,6 +7776,11 @@
         }
       }
     },
+    "loadash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loadash/-/loadash-1.0.0.tgz",
+      "integrity": "sha512-xlX5HBsXB3KG0FJbJJG/3kYWCfsCyCSus3T+uHVu6QL6YxAdggmm3QeyLgn54N2yi5/UE6xxL5ZWJAAiHzHYEg=="
+    },
     "loader-runner": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
@@ -7803,6 +7812,11 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash-es": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -8102,6 +8116,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "material-design-icons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/material-design-icons/-/material-design-icons-3.0.1.tgz",
+      "integrity": "sha1-mnHEh0chjrylHlGmbaaCA4zct78="
     },
     "math-random": {
       "version": "1.0.1",
@@ -10362,6 +10381,27 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
           "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+        }
+      }
+    },
+    "redux-form": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-7.4.0.tgz",
+      "integrity": "sha512-ppFEdbxS+HggJcS+HF37Gwyuh35/54hAZ2e1DvLBEzfw8sTqvas67A1YmfpK9thHj2XyLkwPOSbxgfObfkP+BQ==",
+      "requires": {
+        "es6-error": "^4.1.1",
+        "hoist-non-react-statics": "^2.5.4",
+        "invariant": "^2.2.4",
+        "is-promise": "^2.1.0",
+        "lodash": "^4.17.10",
+        "lodash-es": "^4.17.10",
+        "prop-types": "^15.6.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "4.16.4",
     "express-session": "1.15.6",
     "history": "4.7.2",
+    "material-design-icons": "3.0.1",
     "mongodb": "3.1.10",
     "mongoose": "5.3.14",
     "prop-types": "15.6.2",
@@ -30,6 +31,7 @@
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "redux": "4.0.1",
+    "redux-form": "7.4.0",
     "redux-thunk": "2.3.0"
   },
   "devDependencies": {

--- a/server/models/product.js
+++ b/server/models/product.js
@@ -14,6 +14,15 @@ const productSchema = mongoose.Schema({
   sizeAvailable: { type: Array, required: true },
 });
 
+productSchema.statics.getProduct = (id, callback) => {
+  productModel.find({ _id: id }, (err, product) => {
+    if (err) {
+      return callback(err);
+    }
+    return callback(null, product);
+  });
+};
+
 productSchema.statics.getProducts = (section, type, callback) => {
   productModel.find({ section, type }, (err, products) => {
     if (err) {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -13,6 +13,19 @@ dbconnection.once('open', () => {
   console.log('We are connected');
 });
 
+// Get product
+router.get('/products/:id', (req, res) => {
+  const { id } = req.params;
+  Product.getProduct(id, (err, product) => {
+    if (err) {
+      res.json({ success: false, data: [] });
+    } else {
+      res.json({ success: true, data: product[0] });
+    }
+  });
+});
+
+
 // Get products
 router.get('/products/:section/:type', (req, res) => {
   const { section, type } = req.params;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,6 +5,7 @@ import createHistory from 'history/createBrowserHistory';
 import NavMenu from './common/nav-menu';
 import NavHeader from './common/nav-header';
 import Products from './products';
+import Product from './product';
 import Home from './home';
 
 import '../stylesheets/app.scss';
@@ -18,7 +19,8 @@ const App = () => (
       <NavHeader history={history} />
       <Switch>
         <Route exact path="/home" component={Home} />
-        <Route exact path="/:section/:type" component={Products} />
+        <Route exact path="/products/:section/:type" component={Products} />
+        <Route exact path="/product/:id" component={Product} />
       </Switch>
     </div>
   </Router>

--- a/src/components/common/form/select-input.js
+++ b/src/components/common/form/select-input.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Field } from 'redux-form';
+import PropTypes from 'prop-types';
+import validations from './validations';
+
+const renderField = (fields) => {
+  const {
+    options,
+    meta,
+    placeholder,
+    input,
+  } = fields;
+  const { error } = meta;
+  return (
+    <div className={input.name}>
+      <select {...input}>
+        <option key="default" defaultValue value="">{placeholder}</option>
+        {options.map(size => <option value={size} key={size}>{size}</option>)}
+      </select>
+      {error && <div className="text-danger">{error}</div>}
+    </div>
+  );
+};
+
+// eslint-disable-next-line react/prefer-stateless-function
+class SelectInput extends React.Component {
+  render() {
+    const {
+      name,
+      placeholder,
+      validate,
+      options,
+    } = this.props;
+    const getValidations = () => validate.map(o => validations[o]);
+    return (
+      <Field
+        name={name}
+        placeholder={placeholder}
+        component={renderField}
+        options={options}
+        validate={getValidations()}
+      />
+    );
+  }
+}
+
+SelectInput.defaultProps = {
+  placeholder: 'Please select a value',
+};
+
+SelectInput.propTypes = {
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  validate: PropTypes.array.isRequired,
+  options: PropTypes.array.isRequired,
+};
+
+
+export default SelectInput;

--- a/src/components/common/form/validations.js
+++ b/src/components/common/form/validations.js
@@ -1,0 +1,11 @@
+const isRequired = (value) => {
+  const error = 'You must select a value';
+  if (value === '') {
+    return error;
+  }
+  return undefined;
+};
+
+export default {
+  isRequired,
+};

--- a/src/components/common/nav-header/render-nav-headers.js
+++ b/src/components/common/nav-header/render-nav-headers.js
@@ -27,7 +27,7 @@ class RenderNavHeaders extends React.Component {
 
   handleSelect(eventKey) {
     const { history, section } = this.props;
-    history.push(`/${section}/${eventKey}`);
+    history.push(`/products/${section}/${eventKey}`);
   }
 
   render() {

--- a/src/components/product/add-to-cart-form.js
+++ b/src/components/product/add-to-cart-form.js
@@ -1,0 +1,33 @@
+/* eslint-disable react/prefer-stateless-function */
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import SelectInput from '../common/form/select-input';
+
+class AddToCartForm extends React.Component {
+  render() {
+    const { product, handleSubmit } = this.props;
+    const { sizeAvailable } = product;
+    return (
+      <form onSubmit={handleSubmit}>
+        <SelectInput
+          name="selectSize"
+          options={sizeAvailable}
+          validate={['isRequired']}
+        />
+        <Button type="submit">
+          <i className="material-icons">shopping_basket</i>
+          <span className="btn-caption">Add</span>
+        </Button>
+      </form>
+    );
+  }
+}
+
+AddToCartForm.propTypes = {
+  product: PropTypes.object.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+};
+
+export default reduxForm({ form: 'AddToCartForm' })(AddToCartForm);

--- a/src/components/product/index.js
+++ b/src/components/product/index.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import {
+  Grid, Row, Col,
+} from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import AddToCartForm from './add-to-cart-form';
+import { fetchProductAPI } from '../../store/actions/product';
+
+class Product extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoggedIn: false, // set to true by default for demo purposes
+    };
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentDidMount() {
+    const { fetchProduct, match } = this.props;
+    const { id } = match.params;
+    fetchProduct(id);
+  }
+
+  handleSubmit(fields) {
+    const { product, history } = this.props;
+    const { selectedSize } = fields;
+    const { isLoggedIn } = this.state;
+    if (!isLoggedIn) {
+      const cartProduct = Object.assign(product, { selectedSize }, { amount: 1 });
+      const cart = localStorage.getItem('cart') ? JSON.parse(localStorage.getItem('cart')) : [];
+      cart.push(cartProduct);
+      localStorage.setItem('cart', JSON.stringify(cart));
+    }
+    // Will add logic here once the login and sign up component is completed.
+    history.push('/cart');
+  }
+
+  render() {
+    const { product } = this.props;
+    const {
+      img,
+      name,
+      price,
+    } = product;
+
+    let elem = null;
+
+    if (Object.keys(product).length !== 0) {
+      elem = (
+        <Grid>
+          <Row>
+            <Col xs={10} xsOffset={1} sm={5} md={4}>
+              <img alt={name} src={img} />
+            </Col>
+            <Col xs={10} xsOffset={1} sm={5} md={6} smOffset={1} mdOffset={1}>
+              <div className="label-field">{name}</div>
+              <div className="label-field">
+                $
+                {price}
+              </div>
+              <AddToCartForm product={product} onSubmit={this.handleSubmit} />
+            </Col>
+          </Row>
+        </Grid>
+      );
+    }
+
+    return (
+      <div className="product">
+        {elem}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  product: state.product,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchProduct: (id) => {
+    dispatch(fetchProductAPI(id));
+  },
+});
+
+Product.propTypes = {
+  history: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+  fetchProduct: PropTypes.func.isRequired,
+  product: PropTypes.object.isRequired,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Product);

--- a/src/components/product/index.js
+++ b/src/components/product/index.js
@@ -25,10 +25,10 @@ class Product extends React.Component {
 
   handleSubmit(fields) {
     const { product, history } = this.props;
-    const { selectedSize } = fields;
     const { isLoggedIn } = this.state;
     if (!isLoggedIn) {
-      const cartProduct = Object.assign(product, { selectedSize }, { amount: 1 });
+      const cartProduct = Object.assign(product, fields, { amount: 1 });
+      console.log(cartProduct);
       const cart = localStorage.getItem('cart') ? JSON.parse(localStorage.getItem('cart')) : [];
       cart.push(cartProduct);
       localStorage.setItem('cart', JSON.stringify(cart));

--- a/src/components/products/index.js
+++ b/src/components/products/index.js
@@ -4,9 +4,9 @@ import {
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import ProductList from './productList';
+import ProductList from './product-list';
 import { TYPES } from '../../constants/index';
-import { fetchAllProducts } from '../../store/actions/products';
+import { fetchProductsAPI } from '../../store/actions/products';
 
 class Products extends React.Component {
   componentDidMount() {
@@ -28,7 +28,7 @@ class Products extends React.Component {
     const { section } = match.params;
 
     return (
-      <MenuItem key={type} onClick={() => history.push(`/${section}/${type}`)}>
+      <MenuItem key={type} onClick={() => history.push(`/products/${section}/${type}`)}>
         {type}
       </MenuItem>
     );
@@ -61,7 +61,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchProducts: (section, type) => {
-    dispatch(fetchAllProducts(section, type));
+    dispatch(fetchProductsAPI(section, type));
   },
 });
 

--- a/src/components/products/product-list.js
+++ b/src/components/products/product-list.js
@@ -4,11 +4,17 @@ import { Col } from 'react-bootstrap';
 
 class ProductList extends React.Component {
   renderProducts(product) {
-    const { name, price, img } = product;
+    const {
+      name,
+      price,
+      img,
+      _id,
+    } = product;
+
     const { history } = this.props;
     return (
       <Col xs={6} md={4} key={img} className="single-product">
-        <div className="image" onClick={() => history.push('/placeholderfornow')} role="presentation">
+        <div className="image" onClick={() => history.push(`/product/${_id}`)} role="presentation">
           <img alt={name} src={img} />
         </div>
         <div className="name">{name}</div>

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
     <!-- Latest compiled and minified CSS -->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   </body>
 </html>

--- a/src/store/actions/product.js
+++ b/src/store/actions/product.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import { FETCH_PRODUCT } from './types';
+
+export const fetchProduct = product => ({
+  type: FETCH_PRODUCT,
+  product,
+});
+
+export const fetchProductAPI = id => dispatch => axios({
+  url: `http://localhost:8000/api/products/${id}`,
+  method: 'get',
+})
+  .then((response) => {
+    dispatch(fetchProduct(response.data.data));
+  })
+  .catch((error) => {
+    throw (error);
+  });

--- a/src/store/actions/products.js
+++ b/src/store/actions/products.js
@@ -6,7 +6,7 @@ export const fetchProducts = products => ({
   products,
 });
 
-export const fetchAllProducts = (section, type) => dispatch => axios({
+export const fetchProductsAPI = (section, type) => dispatch => axios({
   url: `http://localhost:8000/api/products/${section}/${type}`,
   method: 'get',
 })

--- a/src/store/actions/types.js
+++ b/src/store/actions/types.js
@@ -1,2 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const FETCH_PRODUCTS = 'FETCH_PRODUCTS';
+
+export const FETCH_PRODUCT = 'FETCH_PRODUCT';

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -1,8 +1,12 @@
 import { combineReducers } from 'redux';
+import { reducer as form } from 'redux-form';
 import products from './products';
+import product from './product';
 
 const rootReducer = combineReducers({
   products,
+  product,
+  form,
 });
 
 export default rootReducer;

--- a/src/store/reducers/product.js
+++ b/src/store/reducers/product.js
@@ -1,0 +1,12 @@
+import { FETCH_PRODUCT } from '../actions/types';
+
+const product = (state = {}, action) => {
+  switch (action.type) {
+    case FETCH_PRODUCT:
+      return action.product;
+    default:
+      return state;
+  }
+};
+
+export default product;

--- a/src/stylesheets/_variables.scss
+++ b/src/stylesheets/_variables.scss
@@ -1,5 +1,6 @@
 // Colors
 $black: rgb(0, 0, 0);
+$white: rgb(255, 255, 255);
 
 // Font
 $font-xsmall: 12px;
@@ -26,3 +27,5 @@ $margin-large: 20px;
 $margin-xlarge: 25px;
 $margin-xxlarge: 30px;
 $margin-xxxlarge: 35px;
+
+$standard-form-element-height: 38px

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -1,2 +1,4 @@
 @import './components/nav-header';
+@import './components/icons';
 @import './components/products';
+@import './components/product';

--- a/src/stylesheets/components/_icons.scss
+++ b/src/stylesheets/components/_icons.scss
@@ -1,0 +1,10 @@
+/* Rules for sizing the icon. */
+.material-icons {
+  margin-right: $margin-medium;
+  &.md-18 { font-size: 18px; }
+  &.md-24 { font-size: 24px; }
+  &.md-36 { font-size: 36px; }
+  &.md-48 { font-size: 48px; }
+  &.md-60 { font-size: 60px; }
+  &.md-72 { font-size: 72px; }
+}

--- a/src/stylesheets/components/_product.scss
+++ b/src/stylesheets/components/_product.scss
@@ -1,0 +1,32 @@
+.product {
+  img {
+    height: 550px;
+    width: 100%;
+  }
+
+  .label-field {
+    font-size: $font-large;
+  }
+
+  form {
+    margin-top: $margin-xxxlarge;
+
+    select {
+      background-color: $white;
+      height: $standard-form-element-height;
+      width: 100%;
+    }
+
+    .btn {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      margin-top: $margin-large;
+      width: 100%;
+
+      .btn-caption {
+        font-size: $font-small;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Changelog
- Added a product section to display a single item product
- Unregistered users can add product to their cart

# Test
- Install dependencies using `npm i`
- Start web app using `npm run start-webapp`
- Start web server using `npm run start-server`
- Navigate to `http://localhost:8080/products/Men/Jeans`
- Click on any of the 6 jeans displayed
- The product page should be displayed listing the name, price and the sizes available.
- Clicking the add button will add the selected product with the selected size to their personal cart. Currently this only works for unregistered users since I haven't done the users component yet.
- Run `JSON.parse(localStorage.getItem('cart'))` on the console if you would like to see the list of items added to your personal cart

# To do after
- Work on the authentication to create the login/sign up component
- I also noticed that my select validation is not working as intended. For some reason the isRequired function is not being triggered so I will need to fix that. I am guessing it works differently for select components?